### PR TITLE
Fix confusion between Z and M

### DIFF
--- a/NetTopologySuite.IO.PostGis/PostGisWriter.cs
+++ b/NetTopologySuite.IO.PostGis/PostGisWriter.cs
@@ -533,7 +533,7 @@ namespace NetTopologySuite.IO
             if ((sequence.Ordinates & Ordinates.M) != 0)
             {
                 if (!double.IsNaN(sequence.GetOrdinate(0, Ordinate.M)))
-                    result |= Ordinates.Z;
+                    result |= Ordinates.M;
             }
             return result;
         }


### PR DESCRIPTION
When detecting the number of ordinates in PostGisWriter