### PR TITLE
Leave Ordinates.None in PostGisWriter to allow detection

### DIFF
--- a/NetTopologySuite.IO.PostGis/PostGisWriter.cs
+++ b/NetTopologySuite.IO.PostGis/PostGisWriter.cs
@@ -554,12 +554,10 @@ namespace NetTopologySuite.IO
         /// <inheritdoc cref="IGeometryIOSettings.HandleOrdinates"/>
         public Ordinates HandleOrdinates
         {
-            get { return _outputOrdinates; }
-            set
-            {
-                value |= Ordinates.XY;
-                _outputOrdinates = value & AllowedOrdinates;
-            }
+            get => _outputOrdinates;
+            set => _outputOrdinates = value == Ordinates.None
+                ? Ordinates.None
+                : (value | Ordinates.XY) & AllowedOrdinates;
         }
         #endregion
 


### PR DESCRIPTION
PostGisWriter contains CheckOrdinates(), which looks at the given geometry object to check which ordinates it contains; this is done only if HandleOrdinates is set to None (i.e. the user hasn't explicitly requested specific ordinates).

However, the HandleOrdinates property ORs XY into the given value, so when the default constructor sets the property to None it gets translated to XY. This means that CheckOrdinates() never gets called.

This changes the HandleOrdinates property to only OR XY into the given value if it is different from None.