### PR TITLE
Handle ordinates for empty `IGeometryCollection`

### DIFF
--- a/NetTopologySuite.IO.PostGis.Test/PostGisTest.cs
+++ b/NetTopologySuite.IO.PostGis.Test/PostGisTest.cs
@@ -199,5 +199,18 @@ namespace NetTopologySuite.IO.PostGis.Test
                 Assert.AreEqual(source.Coordinates[i].Z, target.Coordinates[i].Z);
             }
         }
+
+        [Test]
+        public void GeometryCollection_empty()
+        {
+            IGeometryCollection source = GeometryCollection.Empty;
+
+            // don't assign ordinates, needs to call `CheckOrdinates(...)`
+            byte[] bytes = new PostGisWriter().Write(source);
+
+            IGeometryCollection target = (IGeometryCollection)new PostGisReader().Read(bytes);
+
+            Assert.AreEqual(source.Count, target.Count);
+        }
     }
 }

--- a/NetTopologySuite.IO.PostGis/PostGisWriter.cs
+++ b/NetTopologySuite.IO.PostGis/PostGisWriter.cs
@@ -511,8 +511,8 @@ namespace NetTopologySuite.IO
                 return CheckOrdinates(((ILineString)geometry).CoordinateSequence);
             if (geometry is IPolygon)
                 return CheckOrdinates((((IPolygon)geometry).ExteriorRing).CoordinateSequence);
-            if (geometry is IGeometryCollection)
-                return CheckOrdinates(geometry.GetGeometryN(0));
+            if (geometry is IGeometryCollection collection)
+                return collection.Count == 0 ? Ordinates.None : CheckOrdinates(collection.GetGeometryN(0));
 
             Assert.ShouldNeverReachHere();
             return Ordinates.None;


### PR DESCRIPTION
- npgsql/Npgsql.EntityFrameworkCore.PostgreSQL#732 
- npgsql/npgsql#2258

/cc @roji @YohDeadfall @airbreather 