### PR TITLE
Fix reading POLYGON EMPTY

### DIFF
--- a/src/NetTopologySuite.IO.PostGis/PostGisReader.cs
+++ b/src/NetTopologySuite.IO.PostGis/PostGisReader.cs
@@ -321,13 +321,17 @@ namespace NetTopologySuite.IO
         protected Polygon ReadPolygon(BinaryReader reader, GeometryFactory factory, Ordinates ordinates)
         {
             int numRings = reader.ReadInt32();
-            var exteriorRing = ReadLinearRing(reader, factory, ordinates);
-            var interiorRings = new LinearRing[numRings - 1];
-            for (int i = 0; i < interiorRings.Length; i++)
+            LinearRing exteriorRing = null;
+            LinearRing[] interiorRings = null;
+            if (numRings > 0)
             {
-                interiorRings[i] = ReadLinearRing(reader, factory, ordinates);
+                exteriorRing = ReadLinearRing(reader, factory, ordinates);
+                interiorRings = new LinearRing[numRings - 1];
+                for (int i = 0; i < interiorRings.Length; i++)
+                {
+                    interiorRings[i] = ReadLinearRing(reader, factory, ordinates);
+                }
             }
-
             return factory.CreatePolygon(exteriorRing, interiorRings);
         }
 


### PR DESCRIPTION
I saw an error in the PostgreSQL: 
select ST_GeomFromText('POLYGON EMPTY')

Error with using Npgsql.NetTopologySuite: Unable to read beyond the end of the stream.

This is an error due to an attempt to read at least 1 ring.