### PR TITLE
Use PackedCoordinateSequenceFactory directly when possible for writes

### DIFF
--- a/src/NetTopologySuite.IO.PostGis/NetTopologySuite.IO.PostGis.csproj
+++ b/src/NetTopologySuite.IO.PostGis/NetTopologySuite.IO.PostGis.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>NetTopologySuite.IO</RootNamespace>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/src/NetTopologySuite.IO.PostGis/PostGisWriter.cs
+++ b/src/NetTopologySuite.IO.PostGis/PostGisWriter.cs
@@ -226,7 +226,11 @@ namespace NetTopologySuite.IO
             if (sequence is PackedDoubleCoordinateSequence packedSequence &&
                 byteOrder == ByteOrder.LittleEndian == BitConverter.IsLittleEndian)
             {
-                writer.Write(MemoryMarshal.Cast<double, byte>(packedSequence.GetRawCoordinates()).ToArray());
+#if NETSTANDARD2_1
+                writer.Write(MemoryMarshal.AsBytes<double>(packedSequence.GetRawCoordinates()));
+#else
+                writer.Write(MemoryMarshal.AsBytes<double>(packedSequence.GetRawCoordinates()).ToArray());
+#endif
             }
             else
             {

--- a/src/NetTopologySuite.IO.PostGis/PostGisWriter.cs
+++ b/src/NetTopologySuite.IO.PostGis/PostGisWriter.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
 using NetTopologySuite.Utilities;
 
 namespace NetTopologySuite.IO
@@ -182,7 +184,7 @@ namespace NetTopologySuite.IO
             }
         }
 
-        private static void Write(CoordinateSequence sequence, Ordinates ordinates, BinaryWriter writer, bool justOne)
+        private static void Write(CoordinateSequence sequence, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer, bool justOne)
         {
             if (sequence == null)
                 throw new ArgumentNullException(nameof(sequence));
@@ -221,18 +223,26 @@ namespace NetTopologySuite.IO
                 return;
             }
 
-            for (int i = 0; i < length; i++)
+            if (sequence is PackedDoubleCoordinateSequence packedSequence &&
+                byteOrder == ByteOrder.LittleEndian == BitConverter.IsLittleEndian)
             {
-                writer.Write(sequence.GetX(i));
-                writer.Write(sequence.GetY(i));
-                if (writeZ)
+                writer.Write(MemoryMarshal.Cast<double, byte>(packedSequence.GetRawCoordinates()).ToArray());
+            }
+            else
+            {
+                for (int i = 0; i < length; i++)
                 {
-                    writer.Write(sequence.GetZ(i));
-                }
+                    writer.Write(sequence.GetX(i));
+                    writer.Write(sequence.GetY(i));
+                    if (writeZ)
+                    {
+                        writer.Write(sequence.GetZ(i));
+                    }
 
-                if (writeM)
-                {
-                    writer.Write(sequence.GetM(i));
+                    if (writeM)
+                    {
+                        writer.Write(sequence.GetM(i));
+                    }
                 }
             }
         }
@@ -248,7 +258,7 @@ namespace NetTopologySuite.IO
         private void Write(Point point, Ordinates ordinates, ByteOrder byteOrder, bool emitSRID, BinaryWriter writer)
         {
             WriteHeader(PostGisGeometryType.Point, point.SRID, emitSRID, ordinates, byteOrder, writer);
-            Write(point.CoordinateSequence, ordinates, writer, true);
+            Write(point.CoordinateSequence, ordinates, byteOrder, writer, true);
         }
 
         /// <summary>
@@ -277,7 +287,7 @@ namespace NetTopologySuite.IO
         private void Write(LineString lineString, Ordinates ordinates, ByteOrder byteOrder, bool emitSRID, BinaryWriter writer)
         {
             WriteHeader(PostGisGeometryType.LineString, lineString.SRID, emitSRID, ordinates, byteOrder, writer);
-            Write(lineString.CoordinateSequence, ordinates, writer, false);
+            Write(lineString.CoordinateSequence, ordinates, byteOrder, writer, false);
         }
 
         /// <summary>
@@ -285,10 +295,11 @@ namespace NetTopologySuite.IO
         /// </summary>
         /// <param name="linearRing"></param>
         /// <param name="ordinates"></param>
+        /// <param name="byteOrder"></param>
         /// <param name="writer"></param>
-        private void Write(LinearRing linearRing, Ordinates ordinates, BinaryWriter writer)
+        private void Write(LinearRing linearRing, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
         {
-            Write(linearRing.CoordinateSequence, ordinates, writer, false);
+            Write(linearRing.CoordinateSequence, ordinates, byteOrder, writer, false);
         }
 
         /// <summary>
@@ -313,10 +324,10 @@ namespace NetTopologySuite.IO
             var holes = polygon.Holes;
             writer.Write(holes.Length + 1);
 
-            Write(polygon.Shell, ordinates, writer);
+            Write(polygon.Shell, ordinates, byteOrder, writer);
             for (int i = 0; i < holes.Length; i++)
             {
-                Write(holes[i], ordinates, writer);
+                Write(holes[i], ordinates, byteOrder, writer);
             }
         }
 

--- a/test/NetTopologySuite.IO.PostGis.Benchmarks/NetTopologySuite.IO.PostGis.Benchmarks.csproj
+++ b/test/NetTopologySuite.IO.PostGis.Benchmarks/NetTopologySuite.IO.PostGis.Benchmarks.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)src\NetTopologySuite.IO.PostGis\NetTopologySuite.IO.PostGis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+</Project>

--- a/test/NetTopologySuite.IO.PostGis.Benchmarks/Roundtrip.cs
+++ b/test/NetTopologySuite.IO.PostGis.Benchmarks/Roundtrip.cs
@@ -1,0 +1,56 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Running;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+using Perfolizer.Horology;
+
+namespace NetTopologySuite.IO.PostGis.Benchmarks
+{
+    public class Roundtrip
+    {
+        private static readonly PostGisReader br1 = new PostGisReader();
+        private static readonly PostGisReader br2 = new PostGisReader(new PackedCoordinateSequenceFactory(), new PrecisionModel());
+        private static readonly PostGisWriter bw1 = new PostGisWriter();
+        private static readonly WKTReader wr = new WKTReader();
+
+        private static byte[] pg1;
+
+        public Roundtrip()
+        {
+            var geom = wr.Read("POLYGON((10 10 0,20 10 0,20 20 0,20 10 0,10 10 0),(5 5 0,5 6 0,6 6 0,6 5 0,5 5 0))");
+            pg1 = new PostGisWriter().Write(geom);
+        }
+
+        [Benchmark]
+        public Geometry RoundtripDefault()
+        {
+            var g = br1.Read(pg1);
+            var pgtmp = bw1.Write(g);
+            return br1.Read(pgtmp);
+        }
+
+        [Benchmark]
+        public Geometry RoundtripPackedCoordinateSequenceFactory()
+        {
+            var g = br2.Read(pg1);
+            var pgtmp = bw1.Write(g);
+            return br2.Read(pgtmp);
+        }
+    }
+
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var summaryStyle = new BenchmarkDotNet.Reports.SummaryStyle(null, false, SizeUnit.B, TimeUnit.Microsecond);
+            var config = DefaultConfig.Instance.WithSummaryStyle(summaryStyle);
+            config.AddJob(Job.Default
+               .WithArguments(new[] { new MsBuildArgument("/p:GenerateProgramFile=false") }).AsDefault());
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+        }
+    }
+}


### PR DESCRIPTION
Another follow up to https://github.com/NetTopologySuite/NetTopologySuite.IO.PostGis/issues/16 as I realized the same optimization should work for writes too.

Improvement compared to benchmark in https://github.com/NetTopologySuite/NetTopologySuite.IO.PostGis/pull/18:

|                                   Method |     Mean |     Error |    StdDev |
|----------------------------------------- |---------:|----------:|----------:|
|                         RoundtripDefault | 2.525 us | 0.0254 us | 0.0225 us |
| RoundtripPackedCoordinateSequenceFactory | 1.032 us | 0.0158 us | 0.0140 us |